### PR TITLE
planner comments final mvp

### DIFF
--- a/assets/javascript/planner.js
+++ b/assets/javascript/planner.js
@@ -198,10 +198,6 @@ function weatherb(){
 				newDay.append(newDayContent);
 				$("#planner").append(newDay);
 			}
-			for(i=0; i < 5; i++) {
-				$('#newDayContent').append('<div>' + localStorage.getItem('day1ActivityInput' + i) + '</div>');
-			}
-			
 		});
 	}
 }
@@ -210,17 +206,16 @@ var storageCount = 0;
 var storageArray = [];
 
 //Planner "toDo List" entry
-$('#day1ActivityInput').keypress(function(e) {
+$('#planner').keypress(function(e) {
 	if(e.which == 13) {
 		var textInput = $("#day1ActivityInput").val().trim();
 		var newLine = $("<p>");
 		$("#day1ActivityInput").append(newLine);
 		$("#day1ActivityInput").val('');
 		$('#newDayContent').append(textInput + "<br>");
-	
-		localStorage.setItem('day1ActivityInput', textInput);
 		storageCount++;
 		storageArray.push(textInput);
+		localStorage.setItem('day1ActivityInput', storageArray);
 	}
 });
 


### PR DESCRIPTION
With this addition, we will have a basic working demo for planner comments.  This demo will save an array to local storage, however it will not persist the array onto the window once the user has refreshed the page.  This demo also only works for day one.  The only thing that I touched to make it work was the JS file and the $('#planner').keypress function.  Should be a clean merge (it already says "Able to merge" but after today... I'm going to let someone else have the honors. 
